### PR TITLE
Backwards compatibility with Python 2. Fixes #6.

### DIFF
--- a/hetznercloud/__init__.py
+++ b/hetznercloud/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .client import HetznerCloudClientConfiguration, HetznerCloudClient
 from .constants import *
 from .exceptions import *

--- a/hetznercloud/actions.py
+++ b/hetznercloud/actions.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import time
 
 from .constants import ACTION_STATUS_ERROR
@@ -42,7 +43,7 @@ class HetznerCloudAction(object):
         if self.status == status:
             return
 
-        for i in range(0, attempts):
+        for i in xrange(0, attempts):
             action_status = _get_action_json(self.config, self.id)
             if action_status["status"] == status:
                 self.status = action_status

--- a/hetznercloud/client.py
+++ b/hetznercloud/client.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .floating_ips import HetznerCloudFloatingIpAction
 from .ssh_keys import HetznerCloudSSHKeysAction
 from .images import HetznerCloudImagesAction

--- a/hetznercloud/datacenters.py
+++ b/hetznercloud/datacenters.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .exceptions import HetznerActionException
 from .locations import HetznerCloudLocation
 from .shared import _get_results

--- a/hetznercloud/exceptions.py
+++ b/hetznercloud/exceptions.py
@@ -1,6 +1,6 @@
 class HetznerConfigurationException(Exception):
     def __init__(self, reason):
-        super().__init__("Your Hetzner Cloud configuration is incorrect: %s" % reason)
+        super(HetznerConfigurationException, self).__init__("Your Hetzner Cloud configuration is incorrect: %s" % reason)
 
 
 class HetznerServerNotFoundException(Exception):
@@ -9,28 +9,28 @@ class HetznerServerNotFoundException(Exception):
 
 class HetznerAuthenticationException(Exception):
     def __init__(self):
-        super().__init__("Authenticated failed. Is your API key correct?")
+        super(HetznerAuthenticationException, self).__init__("Authenticated failed. Is your API key correct?")
 
 
 class HetznerInternalServerErrorException(Exception):
     def __init__(self, hetzner_message):
-        super().__init__("The Hetzner Cloud API is currently unavailable: %s" % hetzner_message)
+        super(HetznerInternalServerErrorException, self).__init__("The Hetzner Cloud API is currently unavailable: %s" % hetzner_message)
 
 
 class HetznerInvalidArgumentException(Exception):
     def __init__(self, argument, message=None):
         if message is not None:
-            super().__init__("An invalid argument was (or was not) entered: %s, %s." % (argument, message))
+            super(HetznerInvalidArgumentException, self).__init__("An invalid argument was (or was not) entered: %s, %s." % (argument, message))
         else:
-            super().__init__("An invalid argument was (or was not) entered: %s." % argument)
+            super(HetznerInvalidArgumentException, self).__init__("An invalid argument was (or was not) entered: %s." % argument)
 
 
 class HetznerActionException(Exception):
     def __init__(self, error_code=None):
         if error_code is not None:
-            super().__init__("Failed to perform the requested action: %s" % error_code)
+            super(HetznerActionException, self).__init__("Failed to perform the requested action: %s" % error_code)
         else:
-            super().__init__("Failed to perform the requested action.")
+            super(HetznerActionException, self).__init__("Failed to perform the requested action.")
 
 
 class HetznerWaitAttemptsExceededException(Exception):

--- a/hetznercloud/floating_ips.py
+++ b/hetznercloud/floating_ips.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from hetznercloud.actions import HetznerCloudAction
 from .exceptions import HetznerInvalidArgumentException, HetznerActionException
 from .shared import _get_results

--- a/hetznercloud/images.py
+++ b/hetznercloud/images.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .constants import IMAGE_TYPE_SNAPSHOT
 from .exceptions import HetznerActionException
 from .shared import _get_results

--- a/hetznercloud/isos.py
+++ b/hetznercloud/isos.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .exceptions import HetznerActionException
 from .shared import _get_results
 

--- a/hetznercloud/locations.py
+++ b/hetznercloud/locations.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .exceptions import HetznerActionException
 from .shared import _get_results
 

--- a/hetznercloud/server_types.py
+++ b/hetznercloud/server_types.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .exceptions import HetznerActionException
 from .shared import _get_results
 

--- a/hetznercloud/servers.py
+++ b/hetznercloud/servers.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import time
 
 from .actions import HetznerCloudAction
@@ -277,7 +278,7 @@ class HetznerCloudServer(object):
         if self.status == status:
             return
 
-        for i in range(0, attempts):
+        for i in xrange(0, attempts):
             server_status = _get_server_json(self._config, self.id)["status"]
             if server_status == status:
                 self.status = server_status

--- a/hetznercloud/shared.py
+++ b/hetznercloud/shared.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import json
 
 import requests

--- a/hetznercloud/ssh_keys.py
+++ b/hetznercloud/ssh_keys.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .exceptions import HetznerInvalidArgumentException, HetznerActionException
 from .shared import _get_results
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from setuptools import setup
 
 setup(

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 from hetznercloud import HetznerCloudClient, SERVER_TYPE_1CPU_2GB, IMAGE_UBUNTU_1604, FLOATING_IP_TYPE_IPv4

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from os import environ
 
 from hetznercloud import HetznerCloudClientConfiguration

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 from hetznercloud import HetznerCloudClientConfiguration, HetznerCloudClient, HetznerConfigurationException

--- a/tests/test_datacenters.py
+++ b/tests/test_datacenters.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from tests.base import BaseHetznerTest
 
 

--- a/tests/test_floating_ips.py
+++ b/tests/test_floating_ips.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from hetznercloud import FLOATING_IP_TYPE_IPv4, SERVER_STATUS_RUNNING
 from tests.base import BaseHetznerTest
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from tests.base import BaseHetznerTest
 
 

--- a/tests/test_isos.py
+++ b/tests/test_isos.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from tests.base import BaseHetznerTest
 
 

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from tests.base import BaseHetznerTest
 
 

--- a/tests/test_server_types.py
+++ b/tests/test_server_types.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from tests.base import BaseHetznerTest
 
 

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from hetznercloud import SERVER_STATUS_OFF, ACTION_STATUS_SUCCESS, SERVER_STATUS_RUNNING, \
     BACKUP_WINDOW_10PM_2AM, HetznerActionException, SERVER_TYPE_2CPU_4GB, SERVER_TYPE_1CPU_2GB, IMAGE_UBUNTU_1604
 from tests.base import BaseHetznerTest


### PR DESCRIPTION
This makes the project compatible with Python 2, so that it works on both Python 2 and 3.

My reason to do this is to make it easier to integrate with projects that still require Python 2, such as [nixops](https://github.com/NixOS/nixops).

Achieved via the [3to2](https://pypi.python.org/pypi/3to2) tool:

    3to2 --write --nofix=str .

and subsequent run of

    find . -type f | xargs unix2dos

because the project right now has Windows line endings everywhere.