### PR TITLE
Support server locations.

### DIFF
--- a/hetznercloud/servers.py
+++ b/hetznercloud/servers.py
@@ -20,7 +20,7 @@ class HetznerCloudServersAction(object):
     def __init__(self, config):
         self._config = config
 
-    def create(self, name, server_type, image, datacenter=None, start_after_create=True, ssh_keys=[], user_data=None):
+    def create(self, name, server_type, image, datacenter=None, start_after_create=True, ssh_keys=[], user_data=None, location=None):
         if not name or not server_type or not image:
             raise HetznerInvalidArgumentException("name" if not name
                                                   else "server_type" if not server_type
@@ -34,6 +34,10 @@ class HetznerCloudServersAction(object):
             "start_after_create": start_after_create
         }
 
+        # Giving only `location` instead of `datacenter` is useful if you
+        # want Hetzner to pick a data center within a given location for you.
+        if location is not None:
+            create_params["location"] = location
         if datacenter is not None:
             create_params["datacenter"] = datacenter
         if ssh_keys is not None and len(ssh_keys) > 0:


### PR DESCRIPTION
Improved version of #12

---

See https://docs.hetzner.cloud/#resources-servers-post:

		If you want to create the server in a location, you must set location to the ID or name as listed in /locations. This is the recommended way. You can be even more specific by setting datacenter to the ID or name as listed in /datacenters. However directly specifying the datacenter is discouraged since supply availability in datacenters varies greatly and datacenters may be out of stock for extended periods of time or not serve certain server types at all.