### PR TITLE
corrected status code of ssh_key delete

### DIFF
--- a/hetznercloud/ssh_keys.py
+++ b/hetznercloud/ssh_keys.py
@@ -46,7 +46,7 @@ class HetznerCloudSSHKey(object):
 
     def delete(self):
         status_code, result = _get_results(self._config, "ssh_keys/%s" % self.id, method="DELETE")
-        if status_code != 201:
+        if status_code != 204:
             raise HetznerActionException(result)
 
     def update(self, name):


### PR DESCRIPTION
The Status Code returned from deletion of a ssh key is 204 not 201
https://docs.hetzner.cloud/#ssh-keys-delete-an-ssh-key
