### PR TITLE
Servers' rebuild_from_image function is now returning root password

### DIFF
--- a/hetznercloud/servers.py
+++ b/hetznercloud/servers.py
@@ -251,7 +251,7 @@ class HetznerCloudServer(object):
 
         self.image_id = image
 
-        return HetznerCloudAction._load_from_json(self._config, result["action"])
+        return result["root_password"], HetznerCloudAction._load_from_json(self._config, result["action"])
 
     def reset(self):
         status_code, result = _get_results(self._config, "servers/%s/actions/reset" % self.id, method="POST")


### PR DESCRIPTION
Hi there :) 
This pull request consists of a very simple commit: the `rebuild_from_image` function in the `servers.py` file was only returning the `action` but not the `root_password` (which is actually returned from Hetzner, according to the API [documentation](https://docs.hetzner.cloud/#server-actions-rebuild-a-server-from-an-image)).  
With this single commit, that function is now returning the password as well. I guess this could break some code, since the function is now returning a tuple and not a single value.  
Let me know if you need any further explanation!